### PR TITLE
Config helpers + use PortalTypes vocab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,17 @@
 # Changelog
 
 
-1.0b7 (unreleased)
-------------------
+## 1.0b7 (unreleased)
 
-- Nothing changed yet.
+- Added helpers to `get` and `set` config registry values.
+  [gbastien]
+- Use `plone.app.vocabularies.PortalTypes` instead
+ `plone.app.vocabularies.UserFriendlyTypes` for `allowed_portal_types` and
+ `disallowed_portal_types` config parameters.
+  [gbastien]
 
 
-1.0b6 (2024-04-04)
+## 1.0b6 (2024-04-04)
 
 - Use proper type on the script tags.
   [aduchene]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,8 +9,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/src/imio/webspellchecker/browser/controlpanel.py
+++ b/src/imio/webspellchecker/browser/controlpanel.py
@@ -75,7 +75,7 @@ class IWebspellcheckerControlPanelSchema(Interface):
             "Define the portal types where the webspellchecker will be active."
             "If this is left blank, the webspellchecker will be available on all portal types."
         ),
-        value_type=schema.Choice(vocabulary="plone.app.vocabularies.UserFriendlyTypes"),
+        value_type=schema.Choice(vocabulary="plone.app.vocabularies.PortalTypes"),
         required=False,
         missing_value=[],
         default=[],
@@ -87,7 +87,7 @@ class IWebspellcheckerControlPanelSchema(Interface):
             "Define the portal types where the webspellchecker should not be active."
             "If this is left blank, this setting will be ignored."
         ),
-        value_type=schema.Choice(vocabulary="plone.app.vocabularies.UserFriendlyTypes"),
+        value_type=schema.Choice(vocabulary="plone.app.vocabularies.PortalTypes"),
         required=False,
         missing_value=[],
         default=[],
@@ -97,7 +97,8 @@ class IWebspellcheckerControlPanelSchema(Interface):
     enable_autosearch_in = schema.TextLine(
         title=_("Enable autosearch in"),
         description=_(
-            "The parameter allows enabling the autoSearch mechanism only for elements with provided class, id, data attribute name or HTML elements type. "
+            "The parameter allows enabling the autoSearch mechanism only for elements "
+            "with provided class, id, data attribute name or HTML elements type. "
             "Possible values are: <br>"
             " - '.class' - enable autoSearch for elements with a specified class. <br>"
             " - '#id' - enable autoSearch for elements with a specified id. <br>"
@@ -112,7 +113,8 @@ class IWebspellcheckerControlPanelSchema(Interface):
     disable_autosearch_in = schema.TextLine(
         title=_("Disable autosearch in"),
         description=_(
-            "The parameter allows disabling the autoSearch mechanism by class, id, data attribute name and HTML elements."
+            "The parameter allows disabling the autoSearch mechanism by class, id, "
+            "data attribute name and HTML elements."
             "If enable_autosearch_in option is specified than this option will be ignored. Possible values are: <br>"
             " - '.class' - disable autoSearch for elements with a specified class. <br>"
             " - '#id' - disable autoSearch for elements with a specified id. <br>"

--- a/src/imio/webspellchecker/config.py
+++ b/src/imio/webspellchecker/config.py
@@ -1,0 +1,113 @@
+from copy import deepcopy
+from imio.webspellchecker.browser.controlpanel import IWebspellcheckerControlPanelSchema
+from plone import api
+
+
+def get_enabled():
+    return api.portal.get_registry_record(
+        name='enabled', interface=IWebspellcheckerControlPanelSchema)
+
+
+def get_hide_branding():
+    return api.portal.get_registry_record(
+        name='hide_branding', interface=IWebspellcheckerControlPanelSchema)
+
+
+def get_enable_grammar():
+    return api.portal.get_registry_record(
+        name='enable_grammar', interface=IWebspellcheckerControlPanelSchema)
+
+
+def get_theme():
+    return api.portal.get_registry_record(
+        name='theme', interface=IWebspellcheckerControlPanelSchema)
+
+
+def get_js_bundle_url():
+    return api.portal.get_registry_record(
+        name='js_bundle_url', interface=IWebspellcheckerControlPanelSchema)
+
+
+def get_service_url():
+    return api.portal.get_registry_record(
+        name='service_url', interface=IWebspellcheckerControlPanelSchema)
+
+
+def get_service_id():
+    return api.portal.get_registry_record(
+        name='service_id', interface=IWebspellcheckerControlPanelSchema)
+
+
+def get_allowed_portal_types(as_copy=True):
+    return deepcopy(api.portal.get_registry_record(
+        name='allowed_portal_types', interface=IWebspellcheckerControlPanelSchema))
+
+
+def get_disallowed_portal_types(as_copy=True):
+    return api.portal.get_registry_record(
+        name='disallowed_portal_types', interface=IWebspellcheckerControlPanelSchema)
+
+
+def get_enable_autosearch_in():
+    return api.portal.get_registry_record(
+        name='enable_autosearch_in', interface=IWebspellcheckerControlPanelSchema)
+
+
+def get_disable_autosearch_in():
+    return api.portal.get_registry_record(
+        name='disable_autosearch_in', interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_enabled(value):
+    api.portal.set_registry_record(
+        name='enabled', value=value, interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_hide_branding(value):
+    api.portal.set_registry_record(
+        name='hide_branding', value=value, interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_enable_grammar(value):
+    api.portal.set_registry_record(
+        name='enable_grammar', value=value, interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_theme(value):
+    api.portal.set_registry_record(
+        name='theme', value=value, interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_js_bundle_url(value):
+    api.portal.set_registry_record(
+        name='js_bundle_url', value=value, interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_service_url(value):
+    api.portal.set_registry_record(
+        name='service_url', value=value, interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_service_id(value):
+    api.portal.set_registry_record(
+        name='service_id', value=value, interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_allowed_portal_types(value):
+    api.portal.set_registry_record(
+        name='allowed_portal_types', value=value, interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_disallowed_portal_types(value):
+    api.portal.set_registry_record(
+        name='disallowed_portal_types', value=value, interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_enable_autosearch_in(value):
+    api.portal.set_registry_record(
+        name='enable_autosearch_in', value=value, interface=IWebspellcheckerControlPanelSchema)
+
+
+def set_disable_autosearch_in(value):
+    api.portal.set_registry_record(
+        name='disable_autosearch_in', value=value, interface=IWebspellcheckerControlPanelSchema)


### PR DESCRIPTION
Added helpers to `get` and `set` config registry values.
Use `plone.app.vocabularies.PortalTypes` instead `plone.app.vocabularies.UserFriendlyTypes` for `allowed_portal_types` and
 `disallowed_portal_types` config parameters.